### PR TITLE
Add caveat for MacOS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project will hopefully soon be used to generate
 https://extinctionrebellion.de
 
-Issues and pull requests are very welcome. If something is hart to understand or
+Issues and pull requests are very welcome. If something is hard to understand or
 should be explained in this readme, please also create an Issue.
 
 The same goes for content: If don't feel comfortable making the relevant changes
@@ -13,6 +13,8 @@ yourself, create an Issue.
 1. Checkout the plugins repository: `git submodule update --init`
 2. Install pipenv
    https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv
+   For Mac OSX Users, it is recommended to use a package manager (Homebrew seems to be most convenient): `brew install pipenv`
+   More info about Homebrew: https://brew.sh
 3. `pipenv install --dev`
 
 ## Running the project


### PR DESCRIPTION
Home-brew will side-step any permission issues and auto-link user-installs. It's way more convenient that messing with PATH :trollface: